### PR TITLE
changes to allow for configurion host, user, nopasswd, and command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ The platform has a package named `sudo` and the `sudoers` file is `/etc/sudoers`
 Attributes
 ----------
 - `node['authorization']['sudo']['groups']` - groups to enable sudo access (default: `[ "sysadmin" ]`)
+- `node['authorization']['sudo']['groupsettings']` - groups to enable sudo access along with host, user, nopasswd, and commands options - use overrides groups (default: `[]`)
 - `node['authorization']['sudo']['users']` - users to enable sudo access (default: `[]`)
-- `node['authorization']['sudo']['passwordless']` - use passwordless sudo (default: `false`)
+- `node['authorization']['sudo']['usersettings']` - users to enable sudo access along with host, user, nopasswd, and commands options - use overrides users (default: `[]`)
+- `node['authorization']['sudo']['passwordless']` - use passwordless sudo - not used for groupseetings and usersettings (default: `false`)
 - `node['authorization']['sudo']['include_sudoers_d']` - include and manager `/etc/sudoers.d` (default: `false`)
 - `node['authorization']['sudo']['agent_forwarding']` - preserve `SSH_AUTH_SOCK` when sudoing (default: `false`)
 - `node['authorization']['sudo']['sudoers_defaults']` - Array of `Defaults` entries to configure in `/etc/sudoers`
@@ -33,8 +35,9 @@ To use attributes for defining sudoers, set the attributes above on the node (or
     "authorization": {
       "sudo": {
         "groups": ["admin", "wheel", "sysadmin"],
+        "groupssettings": [{"name": "admin", "hosts": "ALL", "runas": "ALL", "passwordless": "true", "commands": "ALL"}, {"name": "wheel", "hosts": "ALL", "runas": "ALL", "passwordless": "true", "commands": "ALL"}, {"name": "sysadmin", "hosts": "ALL", "runas": "ALL", "commands": "REBOOT"}],
         "users": ["jerry", "greg"],
-        "passwordless": "true"
+        "usersettings": [{"name": "jerry", "hosts": "ALL", "runas": "ALL", "passwordless": "true", "commands": "ALL"}, {"name": "greg", "hosts": "ALL", "runas": "ALL", "commands": "EDIT"}]
       }
     }
   }
@@ -46,9 +49,10 @@ To use attributes for defining sudoers, set the attributes above on the node (or
 default_attributes(
   "authorization" => {
     "sudo" => {
-      "groups" => ["admin", "wheel", "sysadmin"],
+      "groups"=>["admin", "wheel", "sysadmin"],
+      "groupsettings" => [{ "name" => "admin", "hosts" => "ALL", "runas" => "ALL", "passwordless" => "true", "commands" => "ALL"}, {"name" =>  "wheel", "hosts" => "ALL", "runas" => "ALL", "passwordless" => "true", "commands" => "ALL"}, {"name" => "sysadmin", "hosts" => "ALL", "runas" => "ALL", "passwordless" => "false", "commands" => "REBOOT"}],
       "users" => ["jerry", "greg"],
-      "passwordless" => true
+      "usersettings" => [{"name" => "jerry", "hosts" => "ALL", "runas" => "ALL", "passwordless" => "true", "commands" => "ALL"}, {"name" => "greg", "hosts" => "ALL", "runas" => "ALL", "commands" => "EDIT"}]
     }
   }
 )
@@ -236,18 +240,6 @@ case it is not already</td>
       <td>defaults</td>
       <td>array of defaults this user has</td>
       <td><tt>['!requiretty','env_reset']</tt></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>env_keep_add</td>
-      <td>array of strings to add to env_keep</td>
-      <td><tt>['HOME', 'MY_ENV_VAR MY_OTHER_ENV_VAR']</tt></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>env_keep_subtract</td>
-      <td>array of strings to remove from env_keep</td>
-      <td><tt>['DISPLAY', 'MY_SECURE_ENV_VAR']</tt></td>
       <td></td>
     </tr>
     <tr>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,15 +17,15 @@
 # limitations under the License.
 #
 
-default['authorization']['sudo']['groups']            = ['sysadmin']
-default['authorization']['sudo']['users']             = []
+default['authorization']['sudo']['groupsettings']            = [{name: 'sysadmin', hosts: 'ALL', runas: 'ALL', passwordless: 'false', commands: 'ALL'}]
+default['authorization']['sudo']['groups']                   = ['sysadmin']
+default['authorization']['sudo']['usersettings']             = []
+default['authorization']['sudo']['userss']             = []
 default['authorization']['sudo']['passwordless']      = false
 default['authorization']['sudo']['include_sudoers_d'] = false
 default['authorization']['sudo']['agent_forwarding']  = false
 default['authorization']['sudo']['sudoers_defaults']  = ['!lecture,tty_tickets,!fqdn']
 default['authorization']['sudo']['command_aliases']   = []
-default['authorization']['sudo']['env_keep_add']      = []
-default['authorization']['sudo']['env_keep_subtract'] = []
 
 case node['platform_family']
 when 'smartos'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,83 @@
+{
+  "name": "sudo",
+  "version": "2.7.1",
+  "description": "Installs sudo and configures /etc/sudoers",
+  "long_description": "",
+  "maintainer": "Opscode, Inc.",
+  "maintainer_email": "cookbooks@opscode.com",
+  "license": "Apache 2.0",
+  "platforms": {
+    "redhat": ">= 0.0.0",
+    "centos": ">= 0.0.0",
+    "fedora": ">= 0.0.0",
+    "ubuntu": ">= 0.0.0",
+    "debian": ">= 0.0.0",
+    "freebsd": ">= 0.0.0",
+    "mac_os_x": ">= 0.0.0"
+  },
+  "dependencies": {
+  },
+  "recommendations": {
+  },
+  "suggestions": {
+  },
+  "conflicting": {
+  },
+  "providing": {
+  },
+  "replacing": {
+  },
+  "attributes": {
+    "authorization": {
+      "display_name": "Authorization",
+      "description": "Hash of Authorization attributes",
+      "type": "hash"
+    },
+    "authorization/sudo": {
+      "display_name": "Authorization Sudoers",
+      "description": "Hash of Authorization/Sudo attributes",
+      "type": "hash"
+    },
+    "authorization/sudo/users": {
+      "display_name": "Sudo Users",
+      "description": "Users who are allowed sudo ALL",
+      "type": "array",
+      "default": ""
+    },
+    "authorization/sudo/usersettings": {
+      "display_name": "Sudo Users with Settings",
+      "description": "Users who are allowed sudo ALL along with host, commands, and nopasswd settings",
+      "type": "array",
+      "default": ""
+    },
+    "authorization/sudo/groups": {
+      "display_name": "Sudo Groups",
+      "description": "Groups who are allowed sudo ALL",
+      "type": "array",
+      "default": ""
+    },
+    "authorization/sudo/groupsettings": {
+      "display_name": "Sudo Groups with settings",
+      "description": "Groups who are allowed sudo ALL along with host, commands, and nopasswd settings",
+      "type": "array",
+      "default": ""
+    },
+    "authorization/sudo/passwordless": {
+    "display_name": "Passwordless Sudo",
+    "description": "Default NOPASSWD setting for users and groups (not applicable for usersettings and groupsettings)",
+    "type": "string",
+    "default": "false"
+    },
+    "authorization/sudo/include_sudoers_d": {
+      "display_name": "Include sudoers.d",
+      "description": "Whether to create the sudoers.d includedir",
+      "type": "string",
+      "default": "false"
+    }
+  },
+  "groupings": {
+  },
+  "recipes": {
+    "sudo": "Installs sudo and configures /etc/sudoers"
+  }
+}

--- a/metadata.rb
+++ b/metadata.rb
@@ -27,9 +27,21 @@ attribute 'authorization/sudo/users',
   :type         => 'array',
   :default      => ''
 
+attribute 'authorization/sudo/usersettings',
+  :display_name => 'Sudo Users Settings',
+  :description  => 'Users who are allowed sudo along with host, user, nopasswd, and commands options',
+  :type         => 'array',
+  :default      => ''
+
 attribute 'authorization/sudo/groups',
   :display_name => 'Sudo Groups',
   :description  => 'Groups who are allowed sudo ALL',
+  :type         => 'array',
+  :default      => ''
+
+attribute 'authorization/sudo/groupsettings',
+  :display_name => 'Sudo Groups Settings',
+  :description  => 'Groups who are allowed sudo along with host, uer, nopasswd, and commands options.',
   :type         => 'array',
   :default      => ''
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -89,9 +89,7 @@ def render_sudoer
                     :nopasswd => new_resource.nopasswd,
                     :commands => new_resource.commands,
                     :command_aliases => new_resource.command_aliases,
-                    :defaults => new_resource.defaults,
-                    :env_keep_add => new_resource.env_keep_add,
-                    :env_keep_subtract => new_resource.env_keep_subtract
+                    :defaults => new_resource.defaults
       action        :nothing
     end
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,13 +45,13 @@ template "#{prefix}/sudoers" do
   group  node['root_group']
   variables(
     :sudoers_groups    => node['authorization']['sudo']['groups'],
+    :sudoers_groupsettings => node['authorization']['sudo']['groupsettings'],
     :sudoers_users     => node['authorization']['sudo']['users'],
+    :sudoers_usersettings     => node['authorization']['sudo']['usersettings'],
     :passwordless      => node['authorization']['sudo']['passwordless'],
     :include_sudoers_d => node['authorization']['sudo']['include_sudoers_d'],
     :agent_forwarding  => node['authorization']['sudo']['agent_forwarding'],
     :sudoers_defaults  => node['authorization']['sudo']['sudoers_defaults'],
-    :command_aliases   => node['authorization']['sudo']['command_aliases'],
-    :env_keep_add      => node['authorization']['sudo']['env_keep_add'],
-    :env_keep_subtract => node['authorization']['sudo']['env_keep_subtract']
+    :command_aliases   => node['authorization']['sudo']['command_aliases']
   )
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -20,18 +20,18 @@
 actions :install, :remove
 default_action :install
 
-attribute :user,              :kind_of => String,           :default => nil
-attribute :group,             :kind_of => String,           :default => nil
-attribute :commands,          :kind_of => Array,            :default => ['ALL']
-attribute :host,              :kind_of => String,           :default => 'ALL'
-attribute :runas,             :kind_of => String,           :default => 'ALL'
-attribute :nopasswd,          :equal_to => [true, false],   :default => false
-attribute :template,          :kind_of => String,           :default => nil
-attribute :variables,         :kind_of => Hash,             :default => nil
-attribute :defaults,          :kind_of => Array,            :default => []
-attribute :command_aliases,   :kind_of => Array,            :default => []
-attribute :env_keep_add,      :kind_of => Array,            :default => []
-attribute :env_keep_subtract, :kind_of => Array,            :default => []
+attribute :user,            :kind_of => Array,            :default => [] 
+attribute :usersettings,    :kind_of => Array,            :default => []
+attribute :group,           :kind_of => Array,            :default => ['sysadmin']
+attribute :groupsettings,   :kind_of => Array,            :default => []
+attribute :commands,        :kind_of => Array,            :default => ['ALL']
+attribute :host,            :kind_of => String,           :default => 'ALL'
+attribute :runas,           :kind_of => String,           :default => 'ALL'
+attribute :nopasswd,        :equal_to => [true, false],   :default => false
+attribute :template,        :kind_of => String,           :default => nil
+attribute :variables,       :kind_of => Hash,             :default => nil
+attribute :defaults,        :kind_of => Array,            :default => []
+attribute :command_aliases, :kind_of => Array,            :default => []
 
 # Set default for the supports attribute in initializer since it is
 # a 'reserved' attribute name
@@ -43,12 +43,12 @@ end
 
 state_attrs :commands,
             :group,
+            :groupsettings,
             :host,
             :nopasswd,
             :runas,
             :template,
             :user,
+            :usersettings,
             :variables,
-            :command_aliases,
-            :env_keep_add,
-            :env_keep_subtract
+            :command_aliases

--- a/templates/default/sudoer.erb
+++ b/templates/default/sudoer.erb
@@ -5,14 +5,6 @@
 Cmnd_Alias <%= a[:name].upcase %> = <%= a[:command_list].join(', ') %>
 <% end -%>
 
-<% @env_keep_add.each do |env_keep| -%>
-Defaults    env_keep += "<%= env_keep %>"
-<% end -%>
-
-<% @env_keep_subtract.each do |env_keep| -%>
-Defaults    env_keep -= "<%= env_keep %>"
-<% end -%>
-
 <% @commands.each do |command| -%>
 <%= @sudoer %> <%= @host %>=(<%= @runas %>) <%= 'NOPASSWD:' if @nopasswd %><%= command %>
 <% end -%>

--- a/templates/default/sudoers.erb
+++ b/templates/default/sudoers.erb
@@ -15,13 +15,27 @@ root          ALL=(ALL) ALL
 Cmnd_Alias <%= a[:name].upcase %> = <%= a[:command_list].join(', ') %>
 <% end -%>
 
-<% @sudoers_users.each do |user| -%>
+#User privilege specification
+<% if @sudoers_usersettings -%>
+    <% @sudoers_usersettings.each do |user| -%>
+<%= user[:name] %> <%= user[:hosts] %>=(<%= user[:runas] %>) <% if user[:passwordless] -%>NOPASSWD: <%= user[:commands] %> <% else -%><%=  user[:commands] %><% end -%>
+   <% end -%>
+<% else -%>
+    <% @sudoers_users.each do |user| -%>
 <%= user %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+    <% end -%>
 <% end -%>
 
-<% @sudoers_groups.each do |group| -%>
-# Members of the group '<%= group %>' may gain root privileges
-%<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+#Group privilege specification
+<% if @sudoers_groupsettings -%>
+    <% @sudoers_groupsettings.each do |group| -%>
+# Members of the '<%= group[:name] %>' may gain root privileges
+<%= group[:name] %> <%= group[:hosts] %>=(<%= group[:runas] %>) <% if group[:passwordless] -%>NOPASSWD: <%= group[:commands] %> <% else -%><%=  group[:commands] %><% end -%>
+    <% end -%>
+<% else -%>
+    <% @sudoers_groups.each do |group| -%>
+<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+    <% end -%>
 <% end -%>
 
 <%= "#includedir #{node['authorization']['sudo']['prefix']}/sudoers.d" if @include_sudoers_d  %>

--- a/templates/mac_os_x/sudoers.erb
+++ b/templates/mac_os_x/sudoers.erb
@@ -8,16 +8,30 @@ Defaults      <%= defaults %>
 Defaults      env_keep+=SSH_AUTH_SOCK
 <% end -%>
 
-# User privilege specification
+#User privilege specification
 root    ALL=(ALL) ALL
 %admin  ALL=(ALL) ALL
-<% @sudoers_users.each do |user| -%>
+
+<% if @sudoers_usersettings -%>
+    <% @sudoers_usersettings.each do |user| -%>
+<%= user[:name] %> <%= user[:hosts] %>=(<%= user[:runas] %>) <% if user[:passwordless] -%>NOPASSWD: <%= user[:commands] %> <% else -%><%=  user[:commands] %><% end -%>
+   <% end -%>
+<% else -%>
+    <% @sudoers_users.each do |user| -%>
 <%= user %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+    <% end -%>
 <% end -%>
 
-<% @sudoers_groups.each do |group| -%>
-# Members of the group '<%= group %>' may gain root privileges
-%<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+#Group privilege specification
+<% if @sudoers_groupsettings -%>
+    <% @sudoers_groupsettings.each do |group| -%>
+# Members of the '<%= group[:name] %>' may gain root privileges
+<%= group[:name] %> <%= group[:hosts] %>=(<%= group[:runas] %>) <% if group[:passwordless] -%>NOPASSWD: <%= group[:commands] %> <% else -%><%=  group[:commands] %><% end -%>
+    <% end -%>
+<% else -%>
+    <% @sudoers_groups.each do |group| -%>
+<%= group %> ALL=(ALL) <%= "NOPASSWD:" if @passwordless %>ALL
+    <% end -%>
 <% end -%>
 
 <%= "#includedir #{node['authorization']['sudo']['prefix']}/sudoers.d" if @include_sudoers_d  %>


### PR DESCRIPTION
The current sudo recipe only configures sudo access at the root level. Even though you can speficy command aliases there is no way to use them or to set specific host, user, and nopasswd options for each group and/or user. I have added this capability while at the same time retaining backwards compatibility with the existing recipe strucutre. 
